### PR TITLE
Ensure templates adhere to English-only guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Describe a feature request in English.
+title: "[Feature]: "
+labels:
+  - area:BA
+  - area:DEV
+  - area:QA
+  - type:feature
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: Provide a short descriptive title for the request.
+      placeholder: For example, "Add metrics dashboard"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Explain the business context, stakeholders, and goal of the feature.
+      placeholder: Why is this feature important and which problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List measurable acceptance criteria.
+      placeholder: "The user can..."
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Provide links to related documents, tasks, mockups, or discussions.
+      placeholder: Paste URLs or `TASK-###` entries from `docs/hub/TASKS.md`.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Test and Lint Checklist
+- [ ] Linters executed
+- [ ] Tests executed
+
+## AGENTS.md Compliance Checklist
+- [ ] Reviewed AGENTS.md instructions for all modified files
+- [ ] Followed every applicable AGENTS.md requirement
+
+## Related Tasks
+List identifiers from `docs/hub/TASKS.md` in the format `TASK-###` or write `N/A`.
+- `TASK-###`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS Instructions
+
+## Language
+- All repository artifacts must be written in English, regardless of the language used in prompts or discussions.


### PR DESCRIPTION
## Summary
- translate the pull request and feature issue templates into English to enforce the repository language requirement
- add root AGENTS instructions clarifying that all artifacts must be written in English

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7d596f490832a80e110020c6038af