### PR TITLE
Revise PR template for task references and verification checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,10 @@
-## Test and Lint Checklist
-- [ ] Linters executed
-- [ ] Tests executed
+## Task Reference
+- **Task ID:** `T#/INF#/DOC#`
+- **Task Link:** [Task Name](../docs/hub/TASKS.md#row-anchor) <!-- Replace with direct link to the task row -->
 
-## AGENTS.md Compliance Checklist
-- [ ] Reviewed AGENTS.md instructions for all modified files
-- [ ] Followed every applicable AGENTS.md requirement
-
-## Related Tasks
-List identifiers from `docs/hub/TASKS.md` in the format `TASK-###` or write `N/A`.
-- `TASK-###`
+## Verification Checklist
+- [ ] Lint passed
+- [ ] Type checks passed
+- [ ] Tests passed
+- [ ] AGENTS.md contracts respected
+- [ ] Schema changes have matching ADR in `DECISIONS.md`


### PR DESCRIPTION
## Summary
- add a task reference section that captures the task ID and direct link to docs/hub/TASKS.md
- replace the existing checklist with verification boxes for linting, type checks, tests, AGENTS.md compliance, and ADR coverage
- remove references to the old related tasks guidance

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d7db0d7c94832aa6d83298f9603711