### PR TITLE
Retune roadmap for MVP crunch

### DIFF
--- a/docs/hub/ROADMAP.md
+++ b/docs/hub/ROADMAP.md
@@ -1,15 +1,15 @@
 # Roadmap
 
 ## Quarterly Goals
-- **Q1 2024**: Ship MVP agent orchestration toolkit with baseline monitoring.
-- **Q2 2024**: Integrate adaptive prompt library and launch developer portal beta.
-- **Q3 2024**: Achieve production reliability SLA with automated scaling playbooks.
-- **Q4 2024**: Expand multi-agent marketplace and publish extensibility SDK.
+- **Q3 2025 (ends 2025-09-30)**: Ship an integrated BA/DEV/QA MVP by completing context ingestion, automated PR review, and QA test generation flows in a single prototype build.
+- **Q4 2025 (ends 2025-12-31)**: Stabilize the MVP with telemetry hooks, token-budget guardrails, and feedback capture so the hub can support iterative solo maintenance.
+- **Q1 2026 (ends 2026-03-31)**: Expand observability and budgeting into dashboards, alerting, and automated throttles that span BA/DEV/QA workloads.
+- **Q2 2026 (ends 2026-06-30)**: Prepare for partner onboarding by documenting runbooks, polishing deployment automation, and validating guardrails against larger sample projects.
 
 ## Upcoming Tasks
-1. Finalize service-to-service contract for agent messaging.
-2. Draft reliability SLO definitions with observability squad.
-3. Pilot prompt versioning workflow within Codex Hub.
-4. Align marketing site updates with developer portal beta launch.
-5. Establish beta tester feedback loop and reporting cadence.
-6. Document security review checklist for new integrations.
+1. Finalize Firestore schemas and seed data covering briefs, backlog snapshots, and review artifacts to unblock end-to-end demos.
+2. Script the context ingestion worker that listens on Pub/Sub and writes summarized briefs into Firestore.
+3. Implement Vertex AI wrapper helpers for PR summarization, diff explanation, and QA test generation prompts.
+4. Wire GitHub App webhooks to enqueue PR review jobs and persist automated feedback into Firestore collections.
+5. Stand up minimal monitoring by tracking token spend, latency, and Pub/Sub backlog metrics within Cloud Monitoring dashboards.
+6. Add scheduled cleanup tasks that trim stale context documents and enforce storage guardrails ahead of prototype handoff.


### PR DESCRIPTION
## Summary
- reset quarterly goals to start at Q3 2025 and extend through Q2 2026 so milestones remain ahead of today
- align upcoming tasks to the three-day MVP push by detailing ingestion, review, QA, monitoring, and cleanup workstreams

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e68d4e48832a874f4c26d69309ec