### PR TITLE
Update TASKS tracker for MVP roadmap

### DIFF
--- a/docs/hub/TASKS.md
+++ b/docs/hub/TASKS.md
@@ -2,6 +2,9 @@
 
 | ID | Title | Owner | Status | Priority | Links |
 | --- | --- | --- | --- | --- | --- |
-| T-101 | Define agent capability matrix | PM Team | In Progress | High | [Roadmap](./ROADMAP.md) |
-| T-102 | Implement prompt audit logging | Platform Eng | Planned | High | [ADR-0001](./DECISIONS.md) |
-| T-103 | Draft community support playbook | DevRel | Planned | Medium | [Changelog](./CHANGELOG.md) |
+| T1 | Define agent capability matrix | Maintainer | In Progress | High | [Roadmap](./ROADMAP.md) |
+| T2 | Implement prompt audit logging | Maintainer | Backlog | High | [ADR-0001](./DECISIONS.md) |
+| T3 | Draft community support playbook | Maintainer | Backlog | Medium | [Changelog](./CHANGELOG.md) |
+| T4 | Build MVP context pack ingestion | Maintainer | In Progress | High | [Roadmap](./ROADMAP.md) |
+| T5 | Wire automated PR review for MVP | Maintainer | Backlog | High | [Roadmap](./ROADMAP.md) |
+| T6 | Author QA regression tests for MVP | Maintainer | Backlog | High | [Roadmap](./ROADMAP.md) |


### PR DESCRIPTION
## Summary
- Rename existing task identifiers to the T1/T2 format and update references
- Normalize task statuses to the supported workflow categories and refresh ownership where needed
- Add MVP context pack, PR review, and QA testing items to the tracker
- Set all task owners to the Maintainer to reflect solo project work

## Testing
- Not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d7e89f482c832ab36e753065abe219