### PR TITLE
Align hub docs with Agentspace experience and Copilot enablement

### DIFF
--- a/docs/hub/ARCHITECTURE.md
+++ b/docs/hub/ARCHITECTURE.md
@@ -7,6 +7,12 @@ See [detailed architecture](../architecture.md) for comprehensive diagrams and A
 - **Dev Agent** (FastAPI) listens to `context.updated`/`pr.opened` topics, orchestrates pull-request automation, and updates review records.
 - **QA Agent** (FastAPI) subscribes to `test.run.requested`, manages test orchestration, and records run outcomes.
 
+## Agentspace Experience Gateway
+- **UX entry point**: Agentspace delivers a single-pane workflow surfaced through web components and embedded dashboards, routing users to agent-specific actions while enforcing identity and guardrails.
+- **IDE bridge**: GitHub Copilot (or comparable IDE co-pilot) handles inline code edits and draft generation inside the developer workspace, pulling context from Agentspace and pushing updates back through the Dev Agent APIs.
+- **Backend responsibilities**: FastAPI services own long-running orchestration, persistence, and integrations (Firestore, Pub/Sub, Jira, GitHub, TestRail) so the UX layer remains stateless and responsive.
+- **Orchestration**: A lightweight gateway service coordinates authentication tokens, request fan-out to role services, and event acknowledgements so Copilot sessions and Agentspace widgets reflect the same task state in near real time.
+
 ## Shared Libraries
 - `libs/common/google_clients.py` centralises Firestore, Pub/Sub, and Secret Manager client factories.
 - `libs/common/llm.py` and `schemas.py` wrap Vertex AI Gemini responses with JSON schemas (`ContextPack`, `Review`, `TestRun`).

--- a/docs/hub/OVERVIEW.md
+++ b/docs/hub/OVERVIEW.md
@@ -2,8 +2,10 @@
 
 ## Vision & Goals
 - **Purpose**: Deliver a cohesive agent operations hub that aligns business analysis, development, and quality automation around a shared workflow.
-- **Roles in scope**: Business Analyst (BA) orchestrates requirement intelligence, Developer (DEV) automates code delivery, and Quality Analyst (QA) governs validation cycles.
+- **Single front door**: Agentspace acts as the unified UX gateway where BA, DEV, and QA agents authenticate, review signals, and launch actions without tool hopping.
+- **Roles in scope**: Business Analyst (BA) orchestrates requirement intelligence, Developer (DEV) automates code delivery (with GitHub Copilot positioned as the inline coding co-agent), and Quality Analyst (QA) governs validation cycles.
 - **Infrastructure stack**: FastAPI services deployed with Gunicorn/Uvicorn, shared libraries in `libs/common`, Google Cloud Firestore for state, and Pub/Sub topics (`context.updated`, `pr.opened`, `test.run.requested`) for async coordination. See the [service architecture overview](../architecture.md#services) for details.
+- **Cloud guardrails**: Prototype deployments must stay within the Google Cloud Platform free tier (Firestore, Pub/Sub, Cloud Run) until scaling thresholds are proven and budget approvals are secured.
 - **MVP outcomes**: Unified backlog triage, automated PR review prompts, and test run coordination surfaced through the hub so each role can act on current signals without switching tools.
 - **Exclusions for MVP**: Marketplace integrations, adaptive prompt marketplace tooling, and automated scaling playbooks remain post-MVP roadmap items.
 

--- a/docs/hub/ROADMAP.md
+++ b/docs/hub/ROADMAP.md
@@ -1,15 +1,15 @@
 # Roadmap
 
 ## Quarterly Goals
-- **Q3 2025 (ends 2025-09-30)**: Ship an integrated BA/DEV/QA MVP by completing context ingestion, automated PR review, and QA test generation flows in a single prototype build.
-- **Q4 2025 (ends 2025-12-31)**: Stabilize the MVP with telemetry hooks, token-budget guardrails, and feedback capture so the hub can support iterative solo maintenance.
-- **Q1 2026 (ends 2026-03-31)**: Expand observability and budgeting into dashboards, alerting, and automated throttles that span BA/DEV/QA workloads.
-- **Q2 2026 (ends 2026-06-30)**: Prepare for partner onboarding by documenting runbooks, polishing deployment automation, and validating guardrails against larger sample projects.
+- **Q3 2025 (ends 2025-09-30)**: Ship an integrated BA/DEV/QA MVP and deliver Agentspace onboarding flows that guide each role from login through first-task completion.
+- **Q4 2025 (ends 2025-12-31)**: Stabilize the MVP with telemetry hooks, token-budget guardrails, and Copilot-assisted DEV workflows wired through Agentspace widgets.
+- **Q1 2026 (ends 2026-03-31)**: Expand observability and budgeting into dashboards, alerting, and automated throttles that span BA/DEV/QA workloads while monitoring Copilot usage and spend.
+- **Q2 2026 (ends 2026-06-30)**: Prepare for partner onboarding by documenting runbooks, polishing deployment automation, and validating guardrails (including GCP free-tier budgets) against larger sample projects.
 
 ## Upcoming Tasks
 1. Finalize Firestore schemas and seed data covering briefs, backlog snapshots, and review artifacts to unblock end-to-end demos.
 2. Script the context ingestion worker that listens on Pub/Sub and writes summarized briefs into Firestore.
-3. Implement Vertex AI wrapper helpers for PR summarization, diff explanation, and QA test generation prompts.
-4. Wire GitHub App webhooks to enqueue PR review jobs and persist automated feedback into Firestore collections.
-5. Stand up minimal monitoring by tracking token spend, latency, and Pub/Sub backlog metrics within Cloud Monitoring dashboards.
-6. Add scheduled cleanup tasks that trim stale context documents and enforce storage guardrails ahead of prototype handoff.
+3. Implement Agentspace onboarding journeys (role-specific checklists, guardrail prompts, and access verification) surfaced in the UX gateway.
+4. Wire GitHub Copilot context sharing to the Dev Agent so inline suggestions reflect the latest backlog and review signals.
+5. Stand up minimal monitoring by tracking token spend, Copilot usage, latency, and Pub/Sub backlog metrics within Cloud Monitoring dashboards.
+6. Add scheduled cleanup tasks that trim stale context documents and enforce storage guardrails (Firestore, Pub/Sub quotas, Copilot token budgets) ahead of prototype handoff.


### PR DESCRIPTION
## Summary
- position Agentspace as the unified hub entry point and clarify the DEV agent's collaboration with GitHub Copilot while restating GCP free-tier guardrails
- document the Agentspace UX gateway, Copilot/IDE responsibilities, and coordination with backend services
- refresh quarterly goals and tasks to highlight onboarding flows, Copilot enablement, and cloud guardrails

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d7ee371044832aaa0721e74e1d2564