### PR TITLE
Clarify Copilot agent routing and feedback flows

### DIFF
--- a/docs/hub/ARCHITECTURE.md
+++ b/docs/hub/ARCHITECTURE.md
@@ -8,10 +8,10 @@ See [detailed architecture](../architecture.md) for comprehensive diagrams and A
 - **QA Agent** (FastAPI) subscribes to `test.run.requested`, manages test orchestration, and records run outcomes.
 
 ## Agentspace Experience Gateway
-- **UX entry point**: Agentspace delivers a single-pane workflow surfaced through web components and embedded dashboards, routing users to agent-specific actions while enforcing identity and guardrails.
-- **IDE bridge**: GitHub Copilot (or comparable IDE co-pilot) handles inline code edits and draft generation inside the developer workspace, pulling context from Agentspace and pushing updates back through the Dev Agent APIs.
-- **Backend responsibilities**: FastAPI services own long-running orchestration, persistence, and integrations (Firestore, Pub/Sub, Jira, GitHub, TestRail) so the UX layer remains stateless and responsive.
-- **Orchestration**: A lightweight gateway service coordinates authentication tokens, request fan-out to role services, and event acknowledgements so Copilot sessions and Agentspace widgets reflect the same task state in near real time.
+- **Token exchange**: The gateway validates user identity, issues short-lived service tokens to the GitHub Copilot Coding Agent, and signs DEV role requests with scoped Firestore/Pub/Sub claims before dispatching work, logging each issuance for guardrail audits.
+- **Job orchestration**: DEV prompts are normalized into jobs, deduplicated against active Copilot runs, and enqueued; the gateway fans each job into the Copilot Coding Agent while updating backend services (Dev Agent, Firestore) with status checkpoints that track token spend and throttle when budgets tighten.
+- **Callback handling**: Streaming responses and completion callbacks from Copilot land on gateway webhooks, which reconcile job state, persist artifacts through backend APIs, and notify the UX shell via WebSocket updates, annotating which DEV-role sandbox testers initiated each run to capture context for follow-up.
+- **Backend coordination**: FastAPI services remain the system-of-record for orchestration, persistence, and integrations (Firestore, Pub/Sub, Jira, GitHub, TestRail), allowing the gateway to stay stateless while reflecting Copilot progress in near real time.
 
 ## Shared Libraries
 - `libs/common/google_clients.py` centralises Firestore, Pub/Sub, and Secret Manager client factories.

--- a/docs/hub/OVERVIEW.md
+++ b/docs/hub/OVERVIEW.md
@@ -3,9 +3,10 @@
 ## Vision & Goals
 - **Purpose**: Deliver a cohesive agent operations hub that aligns business analysis, development, and quality automation around a shared workflow.
 - **Single front door**: Agentspace acts as the unified UX gateway where BA, DEV, and QA agents authenticate, review signals, and launch actions without tool hopping.
-- **Roles in scope**: Business Analyst (BA) orchestrates requirement intelligence, Developer (DEV) automates code delivery (with GitHub Copilot positioned as the inline coding co-agent), and Quality Analyst (QA) governs validation cycles.
+- **Request routing**: DEV-triggered Copilot jobs are queued in Agentspace, which stamps scoped credentials, forwards the job to the Copilot Coding Agent running in the managed services tier, and streams results back into the shared activity feed while respecting GCP free-tier throttles.
+- **Roles in scope**: Business Analyst (BA) orchestrates requirement intelligence, Developer (DEV) automates code delivery by invoking the server-executed GitHub Copilot Coding Agent through DEV-role jobs, and Quality Analyst (QA) governs validation cycles with Copilot outputs folded into their reviews.
 - **Infrastructure stack**: FastAPI services deployed with Gunicorn/Uvicorn, shared libraries in `libs/common`, Google Cloud Firestore for state, and Pub/Sub topics (`context.updated`, `pr.opened`, `test.run.requested`) for async coordination. See the [service architecture overview](../architecture.md#services) for details.
-- **Cloud guardrails**: Prototype deployments must stay within the Google Cloud Platform free tier (Firestore, Pub/Sub, Cloud Run) until scaling thresholds are proven and budget approvals are secured.
+- **Cloud guardrails**: Prototype deployments must stay within the Google Cloud Platform free tier (Firestore, Pub/Sub, Cloud Run) until scaling thresholds are proven; Copilot job dispatch from Agentspace is throttled when free-tier limits near exhaustion, queuing non-critical runs until budgets refresh.
 - **MVP outcomes**: Unified backlog triage, automated PR review prompts, and test run coordination surfaced through the hub so each role can act on current signals without switching tools.
 - **Exclusions for MVP**: Marketplace integrations, adaptive prompt marketplace tooling, and automated scaling playbooks remain post-MVP roadmap items.
 

--- a/docs/hub/ROADMAP.md
+++ b/docs/hub/ROADMAP.md
@@ -1,15 +1,16 @@
 # Roadmap
 
 ## Quarterly Goals
-- **Q3 2025 (ends 2025-09-30)**: Ship an integrated BA/DEV/QA MVP and deliver Agentspace onboarding flows that guide each role from login through first-task completion.
-- **Q4 2025 (ends 2025-12-31)**: Stabilize the MVP with telemetry hooks, token-budget guardrails, and Copilot-assisted DEV workflows wired through Agentspace widgets.
-- **Q1 2026 (ends 2026-03-31)**: Expand observability and budgeting into dashboards, alerting, and automated throttles that span BA/DEV/QA workloads while monitoring Copilot usage and spend.
-- **Q2 2026 (ends 2026-06-30)**: Prepare for partner onboarding by documenting runbooks, polishing deployment automation, and validating guardrails (including GCP free-tier budgets) against larger sample projects.
+- **Q3 2025 (ends 2025-09-30)**: Ship an integrated BA/DEV/QA MVP, deliver Agentspace onboarding flows, and pilot a Copilot Coding Agent sandbox with DEV role testers.
+- **Q4 2025 (ends 2025-12-31)**: Stabilize the MVP with telemetry hooks, codify Copilot guardrails (token budgets, repository scopes), and graduate the sandbox to limited production via Agentspace widgets.
+- **Q1 2026 (ends 2026-03-31)**: Expand observability and budgeting into dashboards, alerting, and automated throttles while layering Copilot usage telemetry into capacity planning.
+- **Q2 2026 (ends 2026-06-30)**: Prepare for partner onboarding by documenting runbooks, polishing deployment automation, and validating Copilot guardrails (including GCP free-tier budgets) against larger sample projects.
 
 ## Upcoming Tasks
 1. Finalize Firestore schemas and seed data covering briefs, backlog snapshots, and review artifacts to unblock end-to-end demos.
 2. Script the context ingestion worker that listens on Pub/Sub and writes summarized briefs into Firestore.
 3. Implement Agentspace onboarding journeys (role-specific checklists, guardrail prompts, and access verification) surfaced in the UX gateway.
 4. Wire GitHub Copilot context sharing to the Dev Agent so inline suggestions reflect the latest backlog and review signals.
-5. Stand up minimal monitoring by tracking token spend, Copilot usage, latency, and Pub/Sub backlog metrics within Cloud Monitoring dashboards.
-6. Add scheduled cleanup tasks that trim stale context documents and enforce storage guardrails (Firestore, Pub/Sub quotas, Copilot token budgets) ahead of prototype handoff.
+5. Launch a Copilot Coding Agent sandbox environment, capture qualitative feedback from DEV-role sandbox participants exercising the agent end to end, and iterate on prompt/guardrail tuning before broad release.
+6. Stand up minimal monitoring by tracking token spend, Copilot usage, latency, and Pub/Sub backlog metrics within Cloud Monitoring dashboards.
+7. Add scheduled cleanup tasks that trim stale context documents and enforce storage guardrails (Firestore, Pub/Sub quotas, Copilot token budgets) ahead of prototype handoff.


### PR DESCRIPTION
## Summary
- note that Copilot job routing from Agentspace enforces GCP free-tier throttles and folds QA review context into DEV role runs
- expand gateway token exchange, orchestration, and callback descriptions to cover audit logging, budget-aware throttling, and tester attribution
- clarify roadmap sandbox milestone to reference qualitative feedback from DEV-role participants exercising the Copilot agent

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d7f198e9f0832a9432e6cfe860e75c